### PR TITLE
chore: migrate <<HASH>> placeholder to <<VERSION>>

### DIFF
--- a/5V.kicad_sch
+++ b/5V.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(title_block
 		(title "5V HF")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols

--- a/AF_OUT-ADC-filter.kicad_sch
+++ b/AF_OUT-ADC-filter.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(title_block
 		(title "AF_OUT to ADC filter")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols

--- a/DAC-MIC_IN-filter.kicad_sch
+++ b/DAC-MIC_IN-filter.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(title_block
 		(title "DAC to MIC_IN filter")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols

--- a/FMTransceiver.kicad_pcb
+++ b/FMTransceiver.kicad_pcb
@@ -9,7 +9,7 @@
 	(paper "A4")
 	(title_block
 		(title "FM Module")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 		(comment 1 "JLC04161H-7628")
 	)
@@ -18112,7 +18112,7 @@
 			(justify left bottom)
 		)
 	)
-	(gr_text "<<HASH>>"
+	(gr_text "<<VERSION>>"
 		(at 153.797 126.695 0)
 		(layer "F.SilkS")
 		(uuid "3c954e68-d820-45e3-b698-e463f455bc0d")

--- a/FMTransceiver.kicad_sch
+++ b/FMTransceiver.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(title_block
 		(title "FM Module")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols

--- a/connector_cpu.kicad_sch
+++ b/connector_cpu.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(title_block
 		(title "STM32")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols

--- a/pin_driver.kicad_sch
+++ b/pin_driver.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(title_block
 		(title "Pin Driver for the SA818 MOSFET")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols

--- a/pin_driver_npn.kicad_sch
+++ b/pin_driver_npn.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(title_block
 		(title "Pin Driver for the SA818 NPN")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols


### PR DESCRIPTION
## Summary

- Mechanisches sed-Replace `<<HASH>>` → `<<VERSION>>` in allen `.kicad_sch` und `.kicad_pcb`-Files.
- Keine elektrische oder Layout-Änderung — nur der Platzhalter-Name im Titelblock-Silkscreen.

## Phase 3 von 7 — Release-Konzept

- **Phase 1**: VERSIONING.md auf OE5XRX.github.io ([PR #3](https://github.com/OE5XRX/OE5XRX.github.io/pull/3))
- **Phase 2**: HW-Module-CI Workflow-Umstellung ([PR #4](https://github.com/OE5XRX/HW-Module-CI/pull/4)) — **muss zuerst gemergt sein**
- **Phase 3**: Diese PR (5 parallel — 1 pro Modul-Repo)

### Merge-Reihenfolge

1. HW-Module-CI#4 mergen
2. Direkt danach diese PR + die 4 Schwestern in den anderen Modul-Repos

Während des Zeitfensters zeigt das Titelblock kurzzeitig literal `<<HASH>>` (CI sucht nach `<<VERSION>>`, findet nichts, kein Substitut). Beim ersten `push:main` nach den Merges ist alles wieder konsistent.

## Test plan

- [ ] KiCad-Check CI grün (ERC + DRC unverändert)
- [ ] Nach Merge: einmal `workflow_dispatch` von „Create Debug Docs" und sichten dass im PDF-Schaltplan das Titelblock z.B. `BETA-<commit>` zeigt
- [ ] Erst danach `v1.0`-Release triggern (Phase 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)